### PR TITLE
Trapezoidal Rule for the Evaluation of Definite Integrals

### DIFF
--- a/CPlusPlus/math/Trapezoidal_Rule
+++ b/CPlusPlus/math/Trapezoidal_Rule
@@ -1,4 +1,6 @@
-//Trapezoidal Method for the evaluation of Definite Integrals
+/*Trapezoidal Method for the evaluation of Definite Integrals
+*Time complexity= O(n) as only for loop is executed
+*Space complexity=O(n) as there is two double arrays used */
 #include<iostream>
 #include<cmath>
 using namespace std;


### PR DESCRIPTION
The trapezoidal rule is mostly used in the numerical analysis process to evaluate the definite integrals


![Screenshot (2195)](https://user-images.githubusercontent.com/76611051/136374762-bbfe4a34-505c-4037-a6f8-36bec8bed8e5.png)
.